### PR TITLE
[Server] Data storage will updated without clients

### DIFF
--- a/war3observer/server.py
+++ b/war3observer/server.py
@@ -1,18 +1,37 @@
 import asyncio
+import copy
 import websockets
 import json
 import logging
 
 from . import __version__
 from .game import Game
+from . import storage
 
-class Server():
+
+def dump_state(state):
+  event = {'type': 'state', 'content': state}
+  return json.dumps(event, default=lambda o: None)
+
+
+def dump_settings(settings):
+  event = {'type': 'settings', 'content': settings}
+  return json.dumps(event)
+
+
+class Server:
+
+  # How often update state of game (in seconds)
+  refresh_rate = 2
+
+  # How often send data to clients (in seconds)
+  send_client_rate = 5
+
   def setdefaults(config):
-    config.setdefault('loggingLevel', logging.INFO)
+    config.setdefault('loggingLevel', logging.DEBUG)
     config.setdefault('host', 'localhost')
     config.setdefault('port', 8124)
     config.setdefault('clientSettings', {})
-
     return config
 
   def __init__(self, config):
@@ -28,56 +47,45 @@ class Server():
     logging.info('observer %s' % __version__)
     logging.debug('observer - Starting with config %s' % self.config)
 
-    start_server = websockets.serve(self.connect_client, self.config['host'], self.config['port'])
+    start_server = websockets.serve(
+        self.on_client_connect,
+        self.config['host'],
+        self.config['port']
+    )
 
-    asyncio.get_event_loop().run_until_complete(start_server)
-    asyncio.get_event_loop().run_forever()
+    loop = asyncio.get_event_loop()
 
-  def state_event(self, state):
-    return json.dumps({ 'type': 'state', 'content': state }, default=lambda o: None)
+    tasks = [
+      self.update_game_state(),
+      start_server,
+    ]
+    loop.run_until_complete(asyncio.gather(*tasks))
+    loop.run_forever()
 
-  def settings_event(self, settings):
-    return json.dumps({ 'type': 'settings', 'content': settings })
-
-  async def send_state_to_client(self, websocket):
-    while True:
-      try:
-        state = self.game.update()
-      except:
-        logging.exception('An error occurred while updating the game state')
-        state = None
-
-      await websocket.send(self.state_event(state))
-      await asyncio.sleep(2)
-
-  async def receive_client_messages(self, websocket):
-    async for message in websocket:
-      data = json.loads(message)
-      if data['action'] == 'setClientSettings':
-        for other_websocket in self._clients:
-          asyncio.create_task(other_websocket.send(self.settings_event(data['content'])))
-
-  async def connect_client(self, websocket, path):
-    logging.debug('observer - Client connected')
-
+  async def on_client_connect(self, websocket, path):
+    logging.info('Webclient connected')
     self._clients.add(websocket)
 
     try:
-      # Begin by sending the client settings once
-      await websocket.send(self.settings_event(self.config['clientSettings']))
+      # Begin by sending to web client our settings
+      raw_settings = dump_settings(self.config['clientSettings'])
+      await websocket.send(raw_settings)
 
-      # Send an updated state periodically
-      send_state = asyncio.create_task(
-        self.send_state_to_client(websocket))
+      corutines = [
+        # periodically send an updated state
+        self.send_state_to_client(websocket),
 
-      # Check for messages
-      respond = asyncio.create_task(
-        self.receive_client_messages(websocket))
+        # Check for messages from web clients
+        self.receive_client_messages(websocket)
+      ]
 
-      await asyncio.wait([send_state, respond])
+      tasks = [
+        asyncio.create_task(task)
+        for task in corutines
+      ]
+      await asyncio.wait(tasks)
     finally:
-      logging.debug('observer - Client closed')
-
+      logging.info('observer - Client closed')
       self._clients.remove(websocket)
 
       # Stop sending the state
@@ -85,6 +93,52 @@ class Server():
 
       # Close the game if this was the last client
       if not self._clients:
-        logging.debug('observer - Was last client, closing game')
-
+        logging.info('observer - last client closed connection, closing game')
         self.game.close()
+
+  async def update_game_state(self):
+    while True:
+      try:
+        # receive state from game
+        state = self.game.update()
+        storage.Storage.update(state)
+
+        # update refresh rate from game
+        self.refresh_rate = self._get_refresh_rate(state)
+
+        logging.info('Game state updated')
+      except KeyboardInterrupt:
+        raise
+      except:
+        logging.exception('An error occurred while updating the game state')
+
+      await asyncio.sleep(self.refresh_rate)
+
+  async def send_state_to_client(self, websocket):
+    while True:
+      data = dump_state(storage.Storage.state)
+      await websocket.send(data)
+      logging.info('State was send to client')
+
+      await asyncio.sleep(self.send_client_rate)
+
+  async def receive_client_messages(self, websocket):
+    while True:
+      async for message in websocket:
+        data = json.loads(message)
+        if data['action'] == 'setClientSettings':
+          for other_websocket in self._clients:
+            if other_websocket == websocket:
+              continue
+            event = dump_settings(data['content'])
+            await other_websocket.send(event)
+
+      await asyncio.sleep(self.send_client_rate)
+
+  def _get_refresh_rate(self, game_state):
+    """Returns refresh rate from game in seconds."""
+    refresh_rate = game_state.get('game', {}).get('refresh_rate')
+    if refresh_rate:
+      return game['refresh_rate'] // 1000
+
+    return self.refresh_rate

--- a/war3observer/storage.py
+++ b/war3observer/storage.py
@@ -1,0 +1,29 @@
+"""
+Models for store data.
+
+In long term view, it collects and keeps data. Reduces time of refresh
+from web clients to receive data.
+"""
+
+
+class Storage:
+    """Keeps raw events received from game."""
+
+    state = dict()
+    updated = -1
+
+    @classmethod
+    def reset(cls):
+        """Reset state of storage."""
+        cls.state = dict()
+        cls.updated = -1
+
+    @classmethod
+    def update(cls, data):
+        """Updates storage of provided data.
+
+        Data won't be updated when game is paused.
+        """
+        game_time = data['game']['game_time']
+        if game_time > cls.updated:
+            cls.state = data


### PR DESCRIPTION
Hi,

I made some changes due to not working properly `ctrl+c` when no web clients are connected.

Changes:
- added storage module for keep data
- moved function `update_game_state` to task where are server running.
  By this, we receive updates even any client are connected. Ctrl+C is easier to do
- moved function `dump_state` and `dump_settings` as standalone functions